### PR TITLE
Week5 [STEP 2] kokkilE

### DIFF
--- a/CodeStarterCamp_Week5/main.swift
+++ b/CodeStarterCamp_Week5/main.swift
@@ -61,8 +61,8 @@ class TalentedPersonWithBadPersonality: Person, Talent, BadPersonality {
 }
 
 struct AuditionManager {
-    var totalApplicantsList: [Person]
-    var passedApplicantsList: [Person] = []
+    public private(set) var totalApplicantsList: [Person]
+    private var passedApplicantsList: [Person] = []
     
     mutating func cast() {
         for person in totalApplicantsList {
@@ -90,6 +90,17 @@ struct AuditionManager {
             print("합격자가 없습니다.")
         }
     }
+    
+    init(totalApplicantsList: [Person]) {
+        self.totalApplicantsList = totalApplicantsList
+    }
+}
+
+struct Hacker {
+    func hackPassedApplicantsList() {
+        //에러 발생: private으로 접근이 제한되어있는 passedApplicantsList에 접근할 수 없음
+        //auditionManager.passedApplicantsList.append(mySon)
+    }
 }
 
 let yagom = TalentedPerson(name: "yagom", height: 100, singing: .B, dancing: .A, acting: .C)
@@ -101,4 +112,9 @@ let odong = TalentedPersonWithBadPersonality(name: "odong", height: 400, singing
 var auditionManager = AuditionManager(totalApplicantsList: [yagom, noroo, summer, coda, odong])
 
 auditionManager.cast()
+auditionManager.announcePassedApplicants()
+
+let mySon = Person(name: "nalgangdo", height: 10000)
+let hacker = Hacker()
+hacker.hackPassedApplicantsList()
 auditionManager.announcePassedApplicants()


### PR DESCRIPTION
안녕하세요. @wongbingg 
마지막 과제의 PR을 보냅니다. 
그간 감사했습니다! 늘 꼼꼼한 피드백을 해주시는 웡빙님을 학습도우미로 만날 수 있어서 운이 좋았다고 생각합니다 😄 

## 고민했던 점
요구사항에 따라 AuditionManager의 프로퍼티에 접근 수준을 설정하였습니다.
`public private(set) var totalApplicantsList: [Person]` : 읽기 전용
`private var passedApplicantsList: [Person] = []` : 외부에서 읽기, 쓰기 불가능

그런데 위와 같이 접근 수준을 설정하고 나니, 더이상 `Memberwise Initializers`도 활용할 수 없게 되었습니다.
`Memberwise Initializers` 내에서 `private`으로 제한된 프로퍼티의 값을 변경할 경우 `Memberwise Initializers`의 접근 수준도 `private`으로 설정되더라구요. [참고 링크](https://www.hackingwithswift.com/forums/100-days-of-swiftui/why-do-memberwise-initializers-change-to-a-private-access-level-when-a-property-of-its-struct-changes-to-private/15243)

따라서 다음과 같이 이니셜라이저를 추가해주었습니다. `(94 Line)`
```
init(totalApplicantsList: [Person]) {
        self.totalApplicantsList = totalApplicantsList
}
```
위 이니셜라이저는 접근 수준을 명시하지 않았기 때문에 기본값인 `internal`로 설정되어, 구조체 외부에서도 이니셜라이저를 호출할 수 있게 되었습니다.

## 해결이 되지 않은 점

## 조언을 얻고싶은 부분